### PR TITLE
Update MKRWAN.h to expose RX2 parameters

### DIFF
--- a/src/MKRWAN.h
+++ b/src/MKRWAN.h
@@ -670,6 +670,40 @@ public:
     return appskey;
   }
 
+  int getRX2DR() {
+    int dr = -1;
+    sendAT(GF("+RX2DR?"));
+    if (waitResponse("+OK=") == 1) {
+        dr = stream.readStringUntil('\r').toInt();
+    }
+    return dr;
+  }
+
+  bool setRX2DR(uint8_t dr) {
+    sendAT(GF("+RX2DR="),dr);
+    if (waitResponse() != 1) {
+      return false;
+    }
+    return true;
+  }
+
+  uint32_t getRX2Freq() {
+    int freq = -1;
+    sendAT(GF("+RX2FQ?"));
+    if (waitResponse("+OK=") == 1) {
+        freq = stream.readStringUntil('\r').toInt();
+    }
+    return freq;
+  }
+
+  bool setRX2Freq(uint32_t freq) {
+    sendAT(GF("+RX2FQ="),freq);
+    if (waitResponse() != 1) {
+      return false;
+    }
+    return true;
+  }
+
   bool setFCU(uint16_t fcu) {
     sendAT(GF("+FCU="), fcu);
     if (waitResponse() != 1) {


### PR DESCRIPTION
The method setRX2DR is needed to allow receiving downlinks from TTN when using ABP in EU region with SF9-SF12. In this case, TTN chose not to follow the [standard parameters](https://lora-alliance.org/sites/default/files/2018-07/lorawan_regional_parameters_v1.0.3reva_0.pdf) for the RX2 window (that is, SF12 at 869.525KHz), but [is sending at SF9](https://www.thethingsnetwork.org/docs/lorawan/frequency-plans.html).  
Since the MKR WAN 1300 firmware implements the standard, to successfully send downlinks on TTN it is necessary to modify the RX2 data rate to SF9.
This fork adds methods to get and set data rate and, for completeness, frequency, for the RX2 receiving window:
- `getRX2DR()`, to get the current data rate for RX2
- `getRX2Freq()`, to get the current frequency for RX2
- `setRX2DR(uint8_t dr)`, to set data rate for RX2 (the only one really needed: use `modem.setRX2DR(3)` after joining with ABP to set the data rate to SF9)
- `setRX2Freq(uint32_t freq)` to set the RX2 frequency (no need to change it at present).

Please note that when joining with OTAA this is not needed because parameters are communicated back to the node by the network.